### PR TITLE
Add ability to specify log severity

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,14 @@ function logIssue(issue) {
     return `##vso[task.logissue ${attributes.join('')}]${issue.message}`;
 }
 
-module.exports = (results) => {
+module.exports = (results, options) => {
+    options = Object.assign({}, { severity: 'warning' }, options);
+
     const errorLines = _.chain(results)
                         .filter((result) => !result.isEmpty())
                         .flatMap((result) => _.chain(result.getErrorList())
                                               .map((error) => logIssue({
-                                                  type: 'warning',
+                                                  type: options.severity,
                                                   sourcepath: result.getFilename(),
                                                   linenumber: error.line,
                                                   columnnumber: error.column,

--- a/test.js
+++ b/test.js
@@ -86,13 +86,22 @@ test('Given results with no messages, logs nothing', (assert) => {
     assert.is(output.join('').trim(), '');
 });
 
-test('Given results with warnings, logs warnings', (assert) => {
+test('Given results with issues, logs warnings by default', (assert) => {
     const { restore, output, } = stdout.inspect();
 
     reporter(fixture);
 
     restore();
     assert.regex(output.join('').trim(), /##vso\[task\.logissue type=warning/);
+});
+
+test('Given results with issues, logs errors if specified', (assert) => {
+    const { restore, output, } = stdout.inspect();
+
+    reporter(fixture, { severity: 'error' });
+
+    restore();
+    assert.regex(output.join('').trim(), /##vso\[task\.logissue type=error/);
 });
 
 test('Given results with 5 issues, logs 5 issues in valid format', (assert) => {


### PR DESCRIPTION
Although JSCS reporters only officially support one parameter, errorsCollection, it's still beneficial to provide the ability to specify options such as severity level. This allows them to be specified in a custom JSCS reporter like so:

```
const vso = require('jscs-reporter-vso');

module.exports = function (errorsCollection) {
  vso(errorsCollection, { severity: 'error' });
}
```